### PR TITLE
moving async to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,12 +28,13 @@
   ],
   "main": "./lib",
   "dependencies": {
-    "passport-oauth2": "^1.1.2"
+    "passport-oauth2": "^1.1.2",
+    "async": "^0.9.0"
   },
   "engines": {
     "node": ">= 0.10.30"
   },
   "devDependencies": {
-    "async": "^0.9.0"
+    
   }
 }


### PR DESCRIPTION
the `async` lib should be in dependencies. the code is not running otherwise

devDependencies should be used for things that you will only need to develop your code. like unit testing libs and what not
