### PR TITLE
Strategy constructor testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ reports/
 node_modules/
 npm-debug.log
 stunnel*
+
+qualimetry/

--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -93,6 +93,9 @@ function Strategy(options, verify) {
   options.customHeaders = options.customHeaders || {};
 
   OAuth2Strategy.call(this, options, verify);
+  if(!options.clientSecret){
+    throw new TypeError('OAuth2Strategy requires a clientSecret option');
+  }
   this.name = 'bnet';
   this._profileUrl = options.userURL || 'https://' + getMasheryHost(options.region) + '/account/user';
   this._oauth2.useAuthorizationHeaderforGET(true);
@@ -116,11 +119,6 @@ util.inherits(Strategy, OAuth2Strategy);
  * @api protected
  */
 Strategy.prototype.userProfile = function(accessToken, done) {
-  var strategy = this;
-  return strategy.getProfile(accessToken, done);
-};
-
-Strategy.prototype.getProfile = function(accessToken, done) {
   this._oauth2.get(this._profileUrl, accessToken, function (err, body, res) {
     var json;
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
   "license": "MIT",
   "main": "./lib",
   "scripts": {
-    "test": "mocha test/**/*.js"
+    "test": "mocha test/**/*.js",
+    "qualimetry": "istanbul cover _mocha --dir qualimetry/cover -- -R spec test/*"
   },
   "dependencies": {
     "async": "^0.9.0",
@@ -34,6 +35,7 @@
   },
   "devDependencies": {
     "chai": "^3.4.1",
+    "istanbul": "^0.4.3",
     "mocha": "^2.3.4",
     "sinon": "^1.17.2"
   }

--- a/test/strategy.js
+++ b/test/strategy.js
@@ -25,6 +25,33 @@ describe('Strategy', function() {
     }).to.throw(TypeError);
   });
 
+  describe('Strategy constructor', function(){
+    var regionTests = [
+      {masheryExpected:'api.battlenet.com.cn', oauth2Expected:'www.battlenet.com.cn', condition:'region name is "cn"', regionName:'cn'},
+      {masheryExpected:'us.api.battle.net', oauth2Expected:'us.battle.net', condition:'no region name is provided', regionName:''},
+      {masheryExpected:'foobar.api.battle.net', oauth2Expected:'foobar.battle.net', condition:'region name is "foobar" (whatever, except from empty or cn)', regionName:'foobar'}
+    ];
+    regionTests.forEach(function(regionTest){
+      it('should set oauth2 hostname to "'+regionTest.oauth2Expected+'" if '+regionTest.condition, function(){
+        //setup
+        //action
+        var strategy = new BnetStrategy({clientID:'foo', clientSecret:'bar', region:regionTest.regionName}, sinon.spy());
+        //assert
+        expect(strategy._oauth2._authorizeUrl).to.equal('https://'+regionTest.oauth2Expected+'/oauth/authorize');
+        expect(strategy._oauth2._accessTokenUrl).to.equal('https://'+regionTest.oauth2Expected+'/oauth/token');
+      });
+
+      it('should set mashery hostname to "'+regionTest.masheryExpected+'" if '+regionTest.condition, function(){
+        //setup
+        //action
+        var strategy = new BnetStrategy({clientID:'foo', clientSecret:'bar', region:regionTest.regionName}, sinon.spy());
+        //assert
+        expect(strategy._profileUrl).to.equal('https://'+regionTest.masheryExpected+'/account/user');
+      });
+    });
+  });
+
+  //what about empty options ?
   describe('User profile', function() {
 
     var _oauth2Stub;


### PR DESCRIPTION
I refactored a bit the strategy. No new things, but some refactor and new tests.

* (mostly) Added some tests to the constructor to `test edge cases` (host URL building depending on regions) that were not covered like the `"cn" region` handling with the different region names
* Refactored the way the strategy gets profile data by `removing an indirection level for userProfile` that did not seem to have a purpose. Hopefuly improving readability.
* Added `istanbul configuration` to get easy coverage data