### PR TITLE
Add linter

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,4 @@
+module.exports = {
+  "extends": "standard"
+};
+

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,15 +1,14 @@
 /**
  * Module dependencies.
  */
-var Strategy = require('./strategy');
-
+var Strategy = require('./strategy')
 
 /**
  * Expose `Strategy` directly from package.
  */
-module.exports = Strategy;
+module.exports = Strategy
 
 /**
  * Export constructors.
  */
-module.exports.Strategy = Strategy;
+module.exports.Strategy = Strategy

--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -1,10 +1,9 @@
 /**
  * Module dependencies.
  */
-var util = require('util');
-var OAuth2Strategy = require('passport-oauth2');
-var InternalOAuthError = require('passport-oauth2').InternalOAuthError;
-var async = require('async');
+var util = require('util')
+var OAuth2Strategy = require('passport-oauth2')
+var InternalOAuthError = require('passport-oauth2').InternalOAuthError
 
 /**
  * `getHost` utility function
@@ -19,11 +18,11 @@ var async = require('async');
  * @return {String}
  * @api protected
  */
-function getHost(region) {
-  if(region === 'cn') {
-    return 'www.battlenet.com.cn';
+function getHost (region) {
+  if (region === 'cn') {
+    return 'www.battlenet.com.cn'
   } else {
-    return region + '.battle.net';
+    return region + '.battle.net'
   }
 }
 
@@ -40,11 +39,11 @@ function getHost(region) {
  * @return {String}
  * @api protected
  */
-function getMasheryHost(region) {
-  if(region === 'cn') {
-    return 'api.battlenet.com.cn';
+function getMasheryHost (region) {
+  if (region === 'cn') {
+    return 'api.battlenet.com.cn'
   } else {
-    return region + '.api.battle.net';
+    return region + '.api.battle.net'
   }
 }
 
@@ -85,28 +84,27 @@ function getMasheryHost(region) {
  * @param {Function} verify
  * @api public
  */
-function Strategy(options, verify) {
-  options = options || {};
-  options.region = options.region || 'us';
-  options.authorizationURL = options.authorizationURL || 'https://' + getHost(options.region) + '/oauth/authorize';
-  options.tokenURL = options.tokenURL || 'https://' + getHost(options.region) + '/oauth/token';
-  options.scopeSeparator = options.scopeSeparator || ' ';
-  options.customHeaders = options.customHeaders || {};
+function Strategy (options, verify) {
+  options = options || {}
+  options.region = options.region || 'us'
+  options.authorizationURL = options.authorizationURL || 'https://' + getHost(options.region) + '/oauth/authorize'
+  options.tokenURL = options.tokenURL || 'https://' + getHost(options.region) + '/oauth/token'
+  options.scopeSeparator = options.scopeSeparator || ' '
+  options.customHeaders = options.customHeaders || {}
 
-  OAuth2Strategy.call(this, options, verify);
-  if(!options.clientSecret){
-    throw new TypeError('OAuth2Strategy requires a clientSecret option');
+  OAuth2Strategy.call(this, options, verify)
+  if (!options.clientSecret) {
+    throw new TypeError('OAuth2Strategy requires a clientSecret option')
   }
-  this.name = 'bnet';
-  this._profileUrl = options.userURL || 'https://' + getMasheryHost(options.region) + '/account/user';
-  this._oauth2.useAuthorizationHeaderforGET(true);
+  this.name = 'bnet'
+  this._profileUrl = options.userURL || 'https://' + getMasheryHost(options.region) + '/account/user'
+  this._oauth2.useAuthorizationHeaderforGET(true)
 }
 
 /**
  * Inherit from `OAuth2Strategy`.
  */
-util.inherits(Strategy, OAuth2Strategy);
-
+util.inherits(Strategy, OAuth2Strategy)
 
 /**
  * Retrieve user profile from Bnet.
@@ -119,29 +117,29 @@ util.inherits(Strategy, OAuth2Strategy);
  * @param {Function} done
  * @api protected
  */
-Strategy.prototype.userProfile = function(accessToken, done) {
+Strategy.prototype.userProfile = function (accessToken, done) {
   this._oauth2.get(this._profileUrl, accessToken, function (err, body, res) {
-    var json;
+    var json
 
     if (err) {
-      return done(new InternalOAuthError('Failed to fetch the user id', err));
+      return done(new InternalOAuthError('Failed to fetch the user id', err))
     }
 
     try {
-      json = JSON.parse(body);
+      json = JSON.parse(body)
     } catch (ex) {
-      return done(new Error('Failed to parse the user id'));
+      return done(new Error('Failed to parse the user id'))
     }
 
-    var profile = json;
-    profile.provider = 'bnet';
-    profile.token = accessToken;
+    var profile = json
+    profile.provider = 'bnet'
+    profile.token = accessToken
 
-    return done(null, profile);
-  });
-};
+    return done(null, profile)
+  })
+}
 
 /**
  * Expose `Strategy`.
  */
-module.exports = Strategy;
+module.exports = Strategy

--- a/package.json
+++ b/package.json
@@ -24,10 +24,11 @@
   "main": "./lib",
   "scripts": {
     "test": "mocha test/**/*.js",
+    "lint": "eslint lib/",
+    "lint-fix": "eslint lib/ --fix",
     "qualimetry": "istanbul cover _mocha --dir qualimetry/cover -- -R spec test/*"
   },
   "dependencies": {
-    "async": "^0.9.0",
     "passport-oauth2": "^1.1.2"
   },
   "engines": {
@@ -35,6 +36,13 @@
   },
   "devDependencies": {
     "chai": "^3.4.1",
+    "eslint": "^4.4.1",
+    "eslint-config-airbnb-base": "^11.3.1",
+    "eslint-config-standard": "^10.2.1",
+    "eslint-plugin-import": "^2.7.0",
+    "eslint-plugin-node": "^5.1.1",
+    "eslint-plugin-promise": "^3.5.0",
+    "eslint-plugin-standard": "^3.0.1",
     "istanbul": "^0.4.3",
     "mocha": "^2.3.4",
     "sinon": "^1.17.2"


### PR DESCRIPTION
Add a linter using the StandardJS rules. This rules were chosen based on
support for ES5 since Airbnb rules are made for ES6 and StandardJS is
the most common ES5 rule-set.

Linting the code is good for maintaining consistency across the codebase
and helps new contributors to maintain the codestyle.